### PR TITLE
Made keepRunning flag volatile

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
@@ -57,7 +57,7 @@ public class StreamMonitor implements Runnable {
     private AutoscalingConfiguration config;
 
     @SuppressWarnings("unused")
-    private boolean keepRunning = true;
+    private volatile boolean keepRunning = true;
 
     private DateTime lastScaleDown = null;
 


### PR DESCRIPTION
To ensure that when the AutoScalingController sets the flag to false, the change is visible to the StreamMonitor thread.