### PR TITLE
added monitoring of records/second kinesis metric for scaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/target/
+
+.classpath
+
+.project
+
+*.prefs

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ a streamMonitor object is a definition of an Autoscaling Policy applied to a Kin
  "scaleUp": {
      "scaleThresholdPct":Integer - at what threshold we should scale up,
      "scaleAfterMins":Integer - how many minutes above the scaleThresholdPct we should wait before scaling up,
-     "scaleCount":Integer - number of Shards to scale up by,
+     "scaleCount":Integer - number of Shards to scale up by (prevails over scalePct),
      "scalePct":Integer - % of current Stream capacity to scale up by
  },
  "scaleDown":{
      "scaleThresholdPct":Integer - at what threshold we should scale down,
      "scaleAfterMins":Integer - how many minutes below the scaleThresholdPct we should wait before scaling down,
-     "scaleCount":Integer - number of Shards to scale down by,
+     "scaleCount":Integer - number of Shards to scale down by (prevails over scalePct),
      "scalePct":Integer - % of current Stream capacity to scale down by,
      "coolOffMins":Integer - number of minutes to wait after a Stream scale down before we scale down again
  }

--- a/conf/configuration.json
+++ b/conf/configuration.json
@@ -1,0 +1,21 @@
+[
+	{
+        "streamName": "mil-dev-beaconEvents",
+        "region": "eu-west-1",
+        "scaleOnOperation": "PUT",
+        "minShards": 2,
+        "maxShards": 16,
+        "refreshShardsNumberAfterMin": 3,
+        "scaleUp": {
+            "scaleThresholdPct": 75,
+            "scaleAfterMins": 2,
+            "scalePct": 100
+        },
+        "scaleDown": {
+            "scaleThresholdPct": 25,
+            "scaleAfterMins": 2,
+            "scalePct": 50,
+            "coolOffMins": 2
+        }
+    }
+]

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/AlreadyOneShardException.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/AlreadyOneShardException.java
@@ -1,0 +1,42 @@
+/**
+ * Amazon Kinesis Scaling Utility
+ *
+ * Copyright 2014, Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.scaling;
+
+public class AlreadyOneShardException extends Exception {
+
+	public AlreadyOneShardException() {
+		super();
+	}
+
+	public AlreadyOneShardException(String message, Throwable cause,
+			boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public AlreadyOneShardException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AlreadyOneShardException(String message) {
+		super(message);
+	}
+
+	public AlreadyOneShardException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScaler.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScaler.java
@@ -171,6 +171,10 @@ public class StreamScaler {
 
 		int currentSize = StreamScalingUtils.getOpenShardCount(kinesisClient,
 				streamName);
+		
+		if(currentSize == 1) {
+			throw new AlreadyOneShardException();
+		}
 
 		return doResize(streamName, Math.max(currentSize - byShardCount, 1),
 				minShards, maxShards);
@@ -194,6 +198,9 @@ public class StreamScaler {
 
 		int currentSize = StreamScalingUtils.getOpenShardCount(kinesisClient,
 				streamName);
+		if(currentSize == 1) {
+			throw new AlreadyOneShardException();
+		}
 
 		int newSize = Math.max(
 				new Double(Math.ceil(currentSize - (currentSize * scalePct)))

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/AutoscalingConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/AutoscalingConfiguration.java
@@ -56,6 +56,8 @@ public class AutoscalingConfiguration implements Serializable {
 	private Integer minShards;
 
 	private Integer maxShards;
+	
+	private Integer refreshShardsNumberAfterMin;
 
 	public String getStreamName() {
 		return streamName;
@@ -114,6 +116,14 @@ public class AutoscalingConfiguration implements Serializable {
 		this.maxShards = maxShards;
 	}
 
+	public Integer getRefreshShardsNumberAfterMin() {
+		return refreshShardsNumberAfterMin;
+	}
+
+	public void setRefreshShardsNumberAfterMin(Integer refreshShardsNumberAfterMin) {
+		this.refreshShardsNumberAfterMin = refreshShardsNumberAfterMin;
+	}
+
 	public static AutoscalingConfiguration[] loadFromURL(String url)
 			throws IOException {
 		File configFile = null;
@@ -162,8 +172,12 @@ public class AutoscalingConfiguration implements Serializable {
 									(url.startsWith("/") ? "" : "/") + url)
 									.toURI());
 				} else {
-					throw new IOException("Unable to load local file from "
-							+ url);
+					//last fallback to a FS location
+					configFile = new File(url);
+					if(!configFile.exists()) {						
+						throw new IOException("Unable to load local file from "
+								+ url);						
+					}
 				}
 			} catch (URISyntaxException e) {
 				throw new IOException(e);

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/KinesisOperationType.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/KinesisOperationType.java
@@ -16,17 +16,48 @@
  */
 package com.amazonaws.services.kinesis.scaling.auto;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public enum KinesisOperationType {
     PUT {
-        public int getMaxBytes() {
-            return 1_048_576;
+		@Override
+        public StreamMetrics getMaxCapacity() {
+			StreamMetrics metrics = new StreamMetrics();
+			metrics.put(StreamMetric.Bytes, 1_048_576);
+			metrics.put(StreamMetric.Records, 1000);
+			return metrics;
         }
+
+		@Override
+		public List<String> getMetricsToFetch() {
+			List<String> metricsToFetch = new ArrayList<String>();
+			metricsToFetch.add("PutRecord.Bytes");
+			metricsToFetch.add("PutRecords.Bytes");
+			metricsToFetch.add("PutRecord.Success");
+			metricsToFetch.add("PutRecords.Records");
+			return metricsToFetch;
+		}
     },
     GET {
-        public int getMaxBytes() {
-            return 2_097_152;
+		@Override
+        public StreamMetrics getMaxCapacity() {
+			StreamMetrics metrics = new StreamMetrics();
+			metrics.put(StreamMetric.Bytes, 2_097_152);
+			metrics.put(StreamMetric.Records, 2000);
+			return metrics;
         }
+
+		@Override
+		public List<String> getMetricsToFetch() {
+			List<String> metricsToFetch = new ArrayList<String>();
+			metricsToFetch.add("GetRecords.Bytes");
+			metricsToFetch.add("GetRecords.Success");
+			return metricsToFetch;			
+		}
     };
 
-    public abstract int getMaxBytes();
+    public abstract StreamMetrics getMaxCapacity();
+    public abstract List<String> getMetricsToFetch();
+
 }

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetric.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetric.java
@@ -1,0 +1,39 @@
+/**
+ * Amazon Kinesis Scaling Utility
+ *
+ * Copyright 2014, Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.scaling.auto;
+
+public enum StreamMetric {
+	Bytes("Bytes"),
+	Records("Count")
+	;
+
+	private final String unit;
+	
+	StreamMetric(String u) {
+		this.unit = u;
+	}
+	
+	public static StreamMetric fromUnit(String unit) {
+		for (StreamMetric m: values()) {
+			if(m.unit.equals(unit)) {
+				return m;
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetrics.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetrics.java
@@ -1,0 +1,51 @@
+/**
+ * Amazon Kinesis Scaling Utility
+ *
+ * Copyright 2014, Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.scaling.auto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StreamMetrics {
+
+	private final Map<StreamMetric, Integer> metrics = new HashMap<StreamMetric, Integer>();
+
+	
+	public int put(StreamMetric m, int value) {
+		Integer oldValue = metrics.put(m, value);
+		if(oldValue != null) {
+			return oldValue;
+		}
+		return 0;
+	}
+	
+	public int get(StreamMetric m) {
+		Integer metric = metrics.get(m);
+		if(metric != null) {
+			return metric;
+		}
+		return 0;
+	}
+	
+	public int increment(StreamMetric m, int value) {
+		int metric = get(m);
+		metric = metric + value;
+		metrics.put(m, value);
+		return metric;
+	}
+
+
+}


### PR DESCRIPTION
Both bytes/s and records/s are monitored and:
- a scale up is performed if at least one metric has been over the
threashold for the configured minutes
- a scale down is performed if at both metrics (bytes/records) have
been under the threashold for the configured minutes

Added the possibility to put the configuration file anywhere in the FS