### PR TITLE
squid:S2293 - The diamond operator ("<>") should be used

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScalingUtils.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScalingUtils.java
@@ -274,7 +274,7 @@ public class StreamScalingUtils {
 			AmazonKinesisClient kinesisClient, String streamName,
 			SortOrder sortOrder) throws Exception {
 		StreamDescription stream = null;
-		Collection<String> openShardNames = new ArrayList<String>();
+		Collection<String> openShardNames = new ArrayList<>();
 		Map<String, ShardHashInfo> shardMap = new LinkedHashMap<>();
 
 		// load all shards on the stream
@@ -311,7 +311,7 @@ public class StreamScalingUtils {
 		}
 
 		// create a List of Open shards for sorting
-		List<Shard> sortShards = new ArrayList<Shard>();
+		List<Shard> sortShards = new ArrayList<>();
 		for (String s : openShardNames) {
 			// paranoid null check in case we get a null map entry
 			if (s != null) {

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/KinesisOperationType.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/KinesisOperationType.java
@@ -31,7 +31,7 @@ public enum KinesisOperationType {
 
 		@Override
 		public List<String> getMetricsToFetch() {
-			List<String> metricsToFetch = new ArrayList<String>();
+			List<String> metricsToFetch = new ArrayList<>();
 			metricsToFetch.add("PutRecord.Bytes");
 			metricsToFetch.add("PutRecords.Bytes");
 			metricsToFetch.add("PutRecord.Success");
@@ -50,7 +50,7 @@ public enum KinesisOperationType {
 
 		@Override
 		public List<String> getMetricsToFetch() {
-			List<String> metricsToFetch = new ArrayList<String>();
+			List<String> metricsToFetch = new ArrayList<>();
 			metricsToFetch.add("GetRecords.Bytes");
 			metricsToFetch.add("GetRecords.Success");
 			return metricsToFetch;			

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetrics.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetrics.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 public class StreamMetrics {
 
-	private final Map<StreamMetric, Integer> metrics = new HashMap<StreamMetric, Integer>();
+	private final Map<StreamMetric, Integer> metrics = new HashMap<>();
 
 	
 	public int put(StreamMetric m, int value) {

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
@@ -164,7 +164,7 @@ public class StreamMonitor implements Runnable {
 			StreamMetrics streamMaxCapacity, int cwSampleDuration, DateTime now) {
 
 		ScalingOperationReport report = null;
-		Map<StreamMetric, ScaleDirection> scaleDirectionPerMetric = new HashMap<StreamMetric, ScaleDirection>();
+		Map<StreamMetric, ScaleDirection> scaleDirectionPerMetric = new HashMap<>();
 
 		for (StreamMetric metric : metricsMap.keySet()) {
 
@@ -404,7 +404,7 @@ public class StreamMonitor implements Runnable {
 				DateTime metricStartTime = metricEndTime
 						.minusMinutes(cwSampleDuration);
 
-				Map<StreamMetric, Map<Datapoint, Double>> metricsMap = new HashMap<StreamMetric, Map<Datapoint, Double>>();
+				Map<StreamMetric, Map<Datapoint, Double>> metricsMap = new HashMap<>();
 				for (StreamMetric m : StreamMetric.values()) {
 					metricsMap.put(m, new HashMap<Datapoint, Double>());
 				}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - The diamond operator ("<>") should be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2293

Please let me know if you have any questions.

M-Ezzat