### PR TITLE
Multiple quality improvements - squid:S2864, squid:SwitchLastCaseIsDe…

### DIFF
--- a/src/main/java/ScalingClient.java
+++ b/src/main/java/ScalingClient.java
@@ -167,6 +167,8 @@ public class ScalingClient {
 			case pct:
 				report = scaler.scaleUp(this.streamName, this.scalePct, this.minShards, this.maxShards);
 				break;
+			default:
+				break;
 			}
 			break;
 		case scaleDown:
@@ -177,6 +179,8 @@ public class ScalingClient {
 			case pct:
 				report = scaler.scaleDown(this.streamName, this.scalePct, this.minShards, this.maxShards);
 				break;
+			default:
+				break;
 			}
 			break;
 		case resize:
@@ -186,10 +190,14 @@ public class ScalingClient {
 				break;
 			case pct:
 				throw new Exception("Cannot resize by a Percentage");
+				default:
+					break;
 			}
 			break;
 		case report:
 			report = scaler.reportFor(ScalingCompletionStatus.ReportOnly, this.streamName, 0, ScaleDirection.NONE);
+			default:
+				break;
 		}
 
 		System.out.println("Scaling Operation Complete");

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/AutoscalingController.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/AutoscalingController.java
@@ -105,14 +105,14 @@ public class AutoscalingController implements Runnable {
 	}
 
 	public void stopAll() throws Exception {
-		for (Integer i : runningMonitors.keySet()) {
-			StreamMonitor monitor = runningMonitors.get(i);
+		for (Map.Entry<Integer, StreamMonitor> entry : runningMonitors.entrySet()) {
+			StreamMonitor monitor = entry.getValue();
 			LOG.info("Stopping Stream Monitor: "
 					+ monitor.getConfig().getStreamName() + " ...");
 			monitor.stop();
 			// block until the Future returns that the Stream Monitor has
 			// stopped
-			monitorFutures.get(i).get();
+			monitorFutures.get(entry.getKey()).get();
 			LOG.info("Stream Monitor: " + monitor.getConfig().getStreamName()
 					+ " stopped");
 		}
@@ -139,14 +139,14 @@ public class AutoscalingController implements Runnable {
 
 			// spin through all stream monitors to see if any failed
 			while (true) {
-				for (Integer n : monitorFutures.keySet()) {
-					if (monitorFutures.get(n) == null) {
+				for (Map.Entry<Integer, Future<?>> entry : monitorFutures.entrySet()) {
+					if (entry.getValue() == null) {
 						throw new InterruptedException("Null Monitor Future");
 					} else {
-						if (monitorFutures.get(n).isDone()) {
-							if (runningMonitors.get(n).getException() != null) {
+						if (entry.getValue().isDone()) {
+							if (runningMonitors.get(entry.getKey()).getException() != null) {
 								throw new InterruptedException(runningMonitors
-										.get(n).getException().getMessage());
+										.get(entry.getKey()).getException().getMessage());
 							}
 						}
 					}

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetricManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetricManager.java
@@ -147,8 +147,8 @@ public class StreamMetricManager {
 			}
 		}
 
-		for (KinesisOperationType op : this.cloudwatchRequestTemplates.keySet()) {
-			for (GetMetricStatisticsRequest req : this.cloudwatchRequestTemplates.get(op)) {
+		for (Map.Entry<KinesisOperationType, List<GetMetricStatisticsRequest>> entry : this.cloudwatchRequestTemplates.entrySet()) {
+			for (GetMetricStatisticsRequest req : this.cloudwatchRequestTemplates.get(entry.getKey())) {
 				double sampleMetric = 0D;
 
 				req.withStartTime(metricStartTime.toDate()).withEndTime(metricEndTime.toDate());
@@ -164,7 +164,7 @@ public class StreamMetricManager {
 				for (Datapoint d : cloudWatchMetrics.getDatapoints()) {
 					StreamMetric metric = StreamMetric.fromUnit(d.getUnit());
 
-					Map<Datapoint, Double> metrics = currentUtilisationMetrics.get(op).get(metric);
+					Map<Datapoint, Double> metrics = currentUtilisationMetrics.get(entry.getKey()).get(metric);
 					if (metrics == null) {
 						metrics = new HashMap<>();
 					}
@@ -175,7 +175,7 @@ public class StreamMetricManager {
 					}
 					sampleMetric += (d.getSum() / StreamMonitor.CLOUDWATCH_PERIOD);
 					metrics.put(d, sampleMetric);
-					currentUtilisationMetrics.get(op).put(metric, metrics);
+					currentUtilisationMetrics.get(entry.getKey()).put(metric, metrics);
 				}
 			}
 		}

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetrics.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetrics.java
@@ -66,8 +66,8 @@ public class StreamMetrics {
 
 		sb.append(String.format("Operation Type: %s", this.type) + "\n");
 
-		for (StreamMetric metric : this.metrics.keySet()) {
-			sb.append(metric + ":" + this.metrics.get(metric) + "\n");
+		for (Map.Entry<StreamMetric, Integer> entry : this.metrics.entrySet()) {
+			sb.append(entry.getKey() + ":" + this.metrics.get(entry.getKey()) + "\n");
 		}
 
 		return sb.toString();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2864 - "entrySet()" should be iterated when both the key and value are needed
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat