### PR TITLE
squid:S1640 - Maps with keys that are enum values should be replaced …

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetricManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetricManager.java
@@ -17,6 +17,7 @@
 package com.amazonaws.services.kinesis.scaling.auto;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -56,11 +57,11 @@ public class StreamMetricManager {
 	private Set<KinesisOperationType> trackedOperations = new HashSet<>();
 
 	// the current maximum capacity of the stream
-	private Map<KinesisOperationType, StreamMetrics> streamMaxCapacity = new HashMap<>();
+	private Map<KinesisOperationType, StreamMetrics> streamMaxCapacity = new EnumMap<>(KinesisOperationType.class);
 
 	// set of CloudWatch request template objects, which simplify extracting
 	// metrics in future
-	private Map<KinesisOperationType, List<GetMetricStatisticsRequest>> cloudwatchRequestTemplates = new HashMap<>();
+	private Map<KinesisOperationType, List<GetMetricStatisticsRequest>> cloudwatchRequestTemplates = new EnumMap<>(KinesisOperationType.class);
 
 	public StreamMetricManager(String streamName, List<KinesisOperationType> types, AmazonCloudWatch cloudWatchClient,
 			AmazonKinesisClient kinesisClient) {
@@ -133,13 +134,13 @@ public class StreamMetricManager {
 	 */
 	public Map<KinesisOperationType, Map<StreamMetric, Map<Datapoint, Double>>> queryCurrentUtilisationMetrics(
 			int cwSampleDuration, DateTime metricStartTime, DateTime metricEndTime) throws Exception {
-		Map<KinesisOperationType, Map<StreamMetric, Map<Datapoint, Double>>> currentUtilisationMetrics = new HashMap<>();
+		Map<KinesisOperationType, Map<StreamMetric, Map<Datapoint, Double>>> currentUtilisationMetrics = new EnumMap<>(KinesisOperationType.class);
 
 		// seed the current utilisation objects with default Maps to simplify
 		// object creation later
 		for (KinesisOperationType op : this.trackedOperations) {
 			for (StreamMetric m : StreamMetric.values()) {
-				currentUtilisationMetrics.put(op, new HashMap<StreamMetric, Map<Datapoint, Double>>() {
+				currentUtilisationMetrics.put(op, new EnumMap<StreamMetric, Map<Datapoint, Double>>(StreamMetric.class) {
 					{
 						put(m, new HashMap<Datapoint, Double>());
 					}

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetrics.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetrics.java
@@ -16,6 +16,7 @@
  */
 package com.amazonaws.services.kinesis.scaling.auto;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +27,7 @@ public class StreamMetrics {
 		this.type = type;
 	}
 
-	private final Map<StreamMetric, Integer> metrics = new HashMap<>();
+	private final Map<StreamMetric, Integer> metrics = new EnumMap<>(StreamMetric.class);
 
 	public int put(StreamMetric m, int value) {
 		Integer oldValue = metrics.put(m, value);

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
@@ -16,6 +16,7 @@
  */
 package com.amazonaws.services.kinesis.scaling.auto;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -102,13 +103,13 @@ public class StreamMonitor implements Runnable {
 
 		// for each type of operation that the customer has requested profiling
 		// (PUT, GET)
-		Map<KinesisOperationType, ScaleDirection> scaleVotes = new HashMap<>();
+		Map<KinesisOperationType, ScaleDirection> scaleVotes = new EnumMap<>(KinesisOperationType.class);
 
 		for (Map.Entry<KinesisOperationType, Map<StreamMetric, Map<Datapoint, Double>>> entry : currentUtilisationMetrics.entrySet()) {
 			// set the default scaling vote to 'do nothing'
 			scaleVotes.put(entry.getKey(), ScaleDirection.NONE);
 
-			Map<StreamMetric, Triplet<Integer, Integer, Double>> perMetricSamples = new HashMap<>();
+			Map<StreamMetric, Triplet<Integer, Integer, Double>> perMetricSamples = new EnumMap<>(StreamMetric.class);
 			StreamMetric higherUtilisationMetric;
 			Double higherUtilisationPct;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1640 - Maps with keys that are enum values should be replaced with EnumMap

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1640

Please let me know if you have any questions.

M-Ezzat