### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Kinesis Scaling Utility is designed to give you the ability to scale Amazon 
 
 You can also deploy the Web Archive to a Java Application Server, and allow Scaling Utils to automatically manage the number of Shards in the Stream based on the observed PUT or GET rate of the stream. 
 
-##Manually Managing your Stream##
+## Manually Managing your Stream ##
 
 You can manually run the Scaling Utility from the command line by calling the ScalingClient with the following syntax.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
