### PR TITLE
Fix scale down reduce only one shard at one time

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
@@ -309,7 +309,7 @@ public class StreamMonitor implements Runnable {
 						} else {
 							report = this.scaler.updateShardCount(this.config.getStreamName(), currentShardCount,
 									new Double(currentShardCount
-											- (new Double(this.config.getScaleDown().getScalePct()) / 100)).intValue(),
+											* (new Double(this.config.getScaleDown().getScalePct()) / 100)).intValue(),
 									this.config.getMinShards(), this.config.getMaxShards(), false);
 						}
 


### PR DESCRIPTION
*Issue #, if available: #75

*Description of changes:*

I found in the test that scale down only reduces one shard at a time.

The problem should be [here](https://github.com/awslabs/amazon-kinesis-scaling-utils/blob/master/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java#L312)

```java
else {
	report = this.scaler.updateShardCount(this.config.getStreamName(), currentShardCount,
		new Double(currentShardCount - (new Double(this.config.getScaleDown().getScalePct()) / 100)).intValue(),
	this.config.getMinShards(), this.config.getMaxShards(), false);
						}
```

Should be modified to(`+` -> `*`):

```java

else {
	report = this.scaler.updateShardCount(this.config.getStreamName(), currentShardCount,
		new Double(currentShardCount * (new Double(this.config.getScaleDown().getScalePct()) / 100)).intValue(), this.config.getMinShards(), this.config.getMaxShards(), false);
						}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
