### PR TITLE
use docker multi stage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-from maven:3.3.9-jdk-8-alpine
+from maven:3.3.9-jdk-8-alpine AS build-env
+WORKDIR /usr/local/kinesis_scaling
 COPY pom.xml .
 RUN mvn dependency:go-offline
 COPY . .
-RUN mvn install -DskipTests=true -Dlicense.skip=true
-ENTRYPOINT ["java", "-cp", "/dist/KinesisScalingUtils-.9.5.4-complete.jar"]
-    	
+RUN  mvn clean package assembly:assembly
+
+FROM openjdk:8-jre-alpine
+WORKDIR /usr/local/kinesis_scaling
+COPY --from=build-env /usr/local/kinesis_scaling/target/KinesisScalingUtils-.9.5.8-complete.jar ./KinesisScalingUtils-.9.5.8-complete.jar
+COPY ./conf/configuration.json ./conf/
+ENTRYPOINT [ \
+    "java", \
+    "-Dconfig-file-url=/usr/local/kinesis_scaling/conf/configuration.json", \
+    "-cp", \
+    "/usr/local/kinesis_scaling/KinesisScalingUtils-.9.5.8-complete.jar", \
+    "com.amazonaws.services.kinesis.scaling.auto.AutoscalingController" \
+]


### PR DESCRIPTION
the image size can reduce from 300+M to 94M


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
