### PR TITLE
Rethrowing known client exceptions, retrying all others, which hopefully includes timeouts

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetricManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetricManager.java
@@ -32,7 +32,6 @@ import com.amazonaws.services.cloudwatch.model.Datapoint;
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsRequest;
 import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult;
-import com.amazonaws.services.cloudwatch.model.InternalServiceException;
 import com.amazonaws.services.cloudwatch.model.InvalidParameterCombinationException;
 import com.amazonaws.services.cloudwatch.model.InvalidParameterValueException;
 import com.amazonaws.services.cloudwatch.model.MissingRequiredParameterException;

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetricManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetricManager.java
@@ -33,6 +33,9 @@ import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsRequest;
 import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult;
 import com.amazonaws.services.cloudwatch.model.InternalServiceException;
+import com.amazonaws.services.cloudwatch.model.InvalidParameterCombinationException;
+import com.amazonaws.services.cloudwatch.model.InvalidParameterValueException;
+import com.amazonaws.services.cloudwatch.model.MissingRequiredParameterException;
 import com.amazonaws.services.cloudwatch.model.Statistic;
 import com.amazonaws.services.kinesis.AmazonKinesisClient;
 import com.amazonaws.services.kinesis.scaling.StreamScalingUtils;
@@ -168,7 +171,13 @@ public class StreamMetricManager {
 					try {
 						cloudWatchMetrics = this.cloudWatchClient.getMetricStatistics(req);
 						ok = true;
-					} catch (InternalServiceException e) {
+					} catch (InvalidParameterValueException e) {
+						throw e;
+					} catch (MissingRequiredParameterException e) {
+						throw e;
+					} catch (InvalidParameterCombinationException e) {
+						throw e;
+					} catch (Exception e) {
 						// this is probably just a transient error, so retry
 						// after backoff
 						tryCount++;


### PR DESCRIPTION
*Issue #79*

It looks like the intent of this exception handling was to retry all service errors (which should include timeouts). I dug into the `AmazonHttpClient` code to see if I could catch this with a more granular check, but from what I can see if a connect timeout occurs, an unchecked runtime `ClientExecutionTimeoutException` exception is thrown, which derives from `AmazonClientException`  through `SdkClientException`. That exception includes a method, `isRetryable` that might be useful here, but I'm not even sure if a `ClientExecutionTimeoutException` overrides the this method to return `true`. Also, the comments on this flag lead me to believe that it's not really intended to be used externally.

```java
    /**
     * Returns a hint as to whether it makes sense to retry upon this exception.
     * Default is true, but subclass may override.
     *
     * This method is internal to the SDK. Users should not depend on this method to decide
     * if an exception from a service should be retried.
     */
    @SdkInternalApi
    public boolean isRetryable() {
        return true;
    }
```

https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java#L831
https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/http/timers/client/ClientExecutionTimeoutException.java
