### PR TITLE
Inject AWSCredentialsProvider to StreamScaler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.amazonaws</groupId>
 	<artifactId>kinesis-scaling-utils</artifactId>
-	<version>.9.5.8</version>
+	<version>.9.5.9</version>
 	<properties>
 		<sdk-version>1.11.452</sdk-version>
 	</properties>

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScaler.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScaler.java
@@ -16,15 +16,8 @@
  */
 package com.amazonaws.services.kinesis.scaling;
 
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Stack;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.ClasspathPropertiesFileCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
@@ -35,6 +28,14 @@ import com.amazonaws.services.kinesis.model.InvalidArgumentException;
 import com.amazonaws.services.kinesis.model.LimitExceededException;
 import com.amazonaws.services.kinesis.model.ScalingType;
 import com.amazonaws.services.kinesis.model.UpdateShardCountRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
 
 /**
  * Utility for scaling a Kinesis Stream. Places a priority on eventual balancing
@@ -60,7 +61,7 @@ public class StreamScaler {
 
 	private final String AWSApplication = "KinesisScalingUtility";
 
-	public static final String version = ".9.5.7";
+	public static final String version = ".9.5.9";
 
 	private final NumberFormat pctFormat = NumberFormat.getPercentInstance();
 
@@ -76,6 +77,11 @@ public class StreamScaler {
 	}
 
 	public StreamScaler(Region region) throws Exception {
+		this(region, new AWSCredentialsProviderChain(
+			new DefaultAWSCredentialsProviderChain(), new ClasspathPropertiesFileCredentialsProvider()));
+	}
+
+	public StreamScaler(Region region, AWSCredentialsProvider awsCredentialsProvider) throws Exception {
 		pctFormat.setMaximumFractionDigits(1);
 
 		// use the default provider chain plus support for classpath
@@ -90,8 +96,7 @@ public class StreamScaler {
 		userAgent.append(this.version);
 		config.setUserAgent(userAgent.toString());
 
-		kinesisClient = new AmazonKinesisClient(new AWSCredentialsProviderChain(
-				new DefaultAWSCredentialsProviderChain(), new ClasspathPropertiesFileCredentialsProvider()), config);
+		kinesisClient = new AmazonKinesisClient(awsCredentialsProvider, config);
 		kinesisClient.setRegion(region);
 
 		String kinesisEndpoint = System.getProperty("kinesisEndpoint");

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScalingUtils.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScalingUtils.java
@@ -16,20 +16,6 @@
  */
 package com.amazonaws.services.kinesis.scaling;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.math.RoundingMode;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.AmazonKinesisClient;
 import com.amazonaws.services.kinesis.model.DescribeStreamSummaryRequest;
@@ -42,6 +28,20 @@ import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.StreamDescriptionSummary;
 import com.amazonaws.services.kinesis.scaling.StreamScaler.SortOrder;
 import com.amazonaws.services.sns.AmazonSNSClient;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class StreamScalingUtils {
 	private static final Log LOG = LogFactory.getLog(StreamScalingUtils.class);
@@ -263,7 +263,7 @@ public class StreamScalingUtils {
 				.compareTo(new BigInteger(o2.getHashKeyRange().getStartingHashKey()));
 	}
 
-	public static int getOpenShardCount(AmazonKinesisClient kinesisClient, String streamName) throws Exception {
+	public static int getOpenShardCount(AmazonKinesis kinesisClient, String streamName) throws Exception {
 		return StreamScalingUtils.describeStream(kinesisClient, streamName).getOpenShardCount();
 	}
 

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetricManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetricManager.java
@@ -16,17 +16,6 @@
  */
 package com.amazonaws.services.kinesis.scaling.auto;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.joda.time.DateTime;
-
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.model.Datapoint;
 import com.amazonaws.services.cloudwatch.model.Dimension;
@@ -34,8 +23,19 @@ import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsRequest;
 import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult;
 import com.amazonaws.services.cloudwatch.model.InternalServiceException;
 import com.amazonaws.services.cloudwatch.model.Statistic;
-import com.amazonaws.services.kinesis.AmazonKinesisClient;
+import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.scaling.StreamScalingUtils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.joda.time.DateTime;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * The StreamMetricsManager class is responsible for extracting current Stream
@@ -51,7 +51,8 @@ public class StreamMetricManager {
 	public final String CW_NAMESPACE = "AWS/Kinesis";
 	private String streamName;
 	private AmazonCloudWatch cloudWatchClient;
-	private AmazonKinesisClient kinesisClient;
+	private AmazonKinesis kinesisClient;
+	private int cloudWatchPeriod;
 
 	// the set of all Operations that will be tracked in cloudwatch
 	private Set<KinesisOperationType> trackedOperations = new HashSet<>();
@@ -64,11 +65,17 @@ public class StreamMetricManager {
 	private Map<KinesisOperationType, List<GetMetricStatisticsRequest>> cloudwatchRequestTemplates = new HashMap<>();
 
 	public StreamMetricManager(String streamName, List<KinesisOperationType> types, AmazonCloudWatch cloudWatchClient,
-			AmazonKinesisClient kinesisClient) {
+			AmazonKinesis kinesisClient) {
+		this(streamName, StreamMonitor.CLOUDWATCH_PERIOD, types, cloudWatchClient, kinesisClient);
+	}
+
+	public StreamMetricManager(String streamName, int cloudWatchPeriod, List<KinesisOperationType> types, AmazonCloudWatch cloudWatchClient,
+							   AmazonKinesis kinesisClient) {
 		this.streamName = streamName;
 		this.trackedOperations.addAll(types);
 		this.cloudWatchClient = cloudWatchClient;
 		this.kinesisClient = kinesisClient;
+		this.cloudWatchPeriod = cloudWatchPeriod;
 
 		for (KinesisOperationType op : this.trackedOperations) {
 			// create CloudWatch request templates for the information we have
@@ -78,7 +85,7 @@ public class StreamMetricManager {
 
 				cwRequest.withNamespace(CW_NAMESPACE)
 						.withDimensions(new Dimension().withName("StreamName").withValue(this.streamName))
-						.withPeriod(StreamMonitor.CLOUDWATCH_PERIOD).withStatistics(Statistic.Sum)
+						.withPeriod(cloudWatchPeriod).withStatistics(Statistic.Sum)
 						.withMetricName(metricName);
 
 				if (!this.cloudwatchRequestTemplates.containsKey(op)) {
@@ -195,7 +202,7 @@ public class StreamMetricManager {
 					} else {
 						sampleMetric = 0d;
 					}
-					sampleMetric += (d.getSum() / StreamMonitor.CLOUDWATCH_PERIOD);
+					sampleMetric += (d.getSum() / cloudWatchPeriod);
 					metrics.put(d, sampleMetric);
 					currentUtilisationMetrics.get(entry.getKey()).put(metric, metrics);
 				}


### PR DESCRIPTION
Inject cloudwatchPeriod from constructor to StreamMetricManager; Use AmazonKinesis instead of AmazonKinesisClient


*Issue #, if available:*
Some refactor instead of the bug fix.

*Description of changes:*
1. Inject AWSCredentialsProvider to StreamScaler
2. Inject cloudwatchPeriod from constructor to StreamMetricManager
3. Use AmazonKinesis instead of AmazonKinesisClient in some functions of StreamScalingUtils

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
