### PR TITLE
Fix bug in StreamScalingUtils::listShards

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScalingUtils.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScalingUtils.java
@@ -153,7 +153,7 @@ public class StreamScalingUtils {
 				List<Shard> shards = new ArrayList<>();
 
 				while (hasMoreResults) {
-					if (shardIdStart != null) {
+					if (shardIdStart != null && req.getNextToken() == null) {
 						req.withExclusiveStartShardId(shardIdStart);
 					}
 					ListShardsResult result = client.listShards(req);


### PR DESCRIPTION
If the `StreamScalingUtils::listShards` function is called with a not-null `shardIdStart` and the stream has over 1000 shards, the call will fail with this error:
```
com.amazonaws.services.kinesis.model.InvalidArgumentException: NextToken and ExclusiveStartShardId cannot be provided together.
```

That's because the second request to the `ListShards` API has both `ExclusiveStartShardId` and `NextToken` populated.

*Issue #, if available:*
N/A

*Description of changes:*
Populate `ExclusiveStartShardId` only if `NextToken` in the request is null.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
