### PR TITLE
Fix broken formatting in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ once you've built the Autoscaling configuration required, save it to an HTTP fil
         }
     }
 ]
+```
 
 ## Autoscaling Behaviour ##
 


### PR DESCRIPTION
*Description of changes:* We forgot to put a \`\`\` at the end of the second config example, leading to the table being pretty difficult to read. This PR adds back in that ```