### PR TITLE
Clear up wording around scalePct

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ once you've built the Autoscaling configuration required, save it to an HTTP fil
 ]
 ```
 
-Note that the `scalePct` parameter refers to the percentage of existing capacity that we'll scale to - it says "scale up **to** rather than scale up **by**. This means that in the above example, when a scale up is triggered, the autoscaler will double the capacity of the stream - scaling up to 200% of its existing capacity. When a scale down is triggered, it will scale down to 3/4 of its existing capacity.
+Note that the `scalePct` parameter refers to the percentage of existing capacity that we'll scale to - it says "scale up **to**" rather than "scale up **by**". This means that in the above example, when a scale up is triggered, the autoscaler will double the capacity of the stream - scaling up to 200% of its existing capacity. When a scale down is triggered, it will scale down to 3/4 of its existing capacity.
 
 ## Autoscaling Behaviour ##
 

--- a/README.md
+++ b/README.md
@@ -139,19 +139,21 @@ once you've built the Autoscaling configuration required, save it to an HTTP fil
        "scaleUp": {
             "scaleThresholdPct": 75,
             "scaleAfterMins": 1,
-            "scalePct": 100,
+            "scalePct": 200,
             "notificationARN": "arn:aws:sns:region:accountId:topicName"
         },
         "scaleDown": {
             "scaleThresholdPct": 25,
             "scaleAfterMins": 1,
-            "scalePct": 50,
+            "scalePct": 75,
             "coolOffMins": 1,
             "notificationARN": "arn:aws:sns:region:accountId:topicName"
         }
     }
 ]
 ```
+
+Note that the `scalePct` parameter refers to the percentage of existing capacity that we'll scale to - it says "scale up **to** rather than scale up **by**. This means that in the above example, when a scale up is triggered, the autoscaler will double the capacity of the stream - scaling up to 200% of its existing capacity. When a scale down is triggered, it will scale down to 3/4 of its existing capacity.
 
 ## Autoscaling Behaviour ##
 


### PR DESCRIPTION
*Description of changes:*
In the existing readme, the behaviour of `scalePct` wasn't clear - would setting it to `115%` increase our shard count by 15%, or would it slightly more than double our capacity? This commit adds an explanation to the behaviour of `scalePct`, and also removes the `scalePct: 100` value from the example configuration, which if used as is would cause the autoscaler to crash, as 100% is an invalid scaling percentage.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
