### PR TITLE
Fix bugs on stream metrics retrieval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ RUN  mvn clean package assembly:assembly
 
 FROM openjdk:8-jre-alpine
 WORKDIR /usr/local/kinesis_scaling
-COPY --from=build-env /usr/local/kinesis_scaling/target/KinesisScalingUtils-.9.7.0-complete.jar ./KinesisScalingUtils-.9.7.0-complete.jar
+COPY --from=build-env /usr/local/kinesis_scaling/target/KinesisScalingUtils-.9.8.0-complete.jar ./KinesisScalingUtils-.9.8.0-complete.jar
 COPY ./conf/configuration.json ./conf/
 ENTRYPOINT [ \
     "java", \
     "-Dconfig-file-url=/usr/local/kinesis_scaling/conf/configuration.json", \
     "-cp", \
-    "/usr/local/kinesis_scaling/KinesisScalingUtils-.9.7.0-complete.jar", \
+    "/usr/local/kinesis_scaling/KinesisScalingUtils-.9.8.0-complete.jar", \
     "com.amazonaws.services.kinesis.scaling.auto.AutoscalingController" \
 ]

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ In version .9.5.0, Autoscaling added the ability to scale on the basis of PUT __
 | | | PUT | | |
 | :-- | :-- | :--: | :--: | :--: |
 | | __Range__ | Below | In | Above |
-|__GET__ | Below | Down | Down | Up |
-| | In | Down | Do Nothing | Up |
+|__GET__ | Below | Down | No Nothing | Up |
+| | In | No Nothing | Do Nothing | Up |
 | | Above | Up | Up | Up
 
 ## Monitoring Autoscaling

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ In version .9.5.0, Autoscaling added the ability to scale on the basis of PUT __
 | | | PUT | | |
 | :-- | :-- | :--: | :--: | :--: |
 | | __Range__ | Below | In | Above |
-|__GET__ | Below | Down | No Nothing | Up |
-| | In | No Nothing | Do Nothing | Up |
+|__GET__ | Below | Down | Do Nothing | Up |
+| | In | Do Nothing | Do Nothing | Up |
 | | Above | Up | Up | Up
 
 ## Monitoring Autoscaling

--- a/README.md
+++ b/README.md
@@ -48,24 +48,24 @@ Below you can see a graph of how Autoscaling will keep adequate Shard capacity t
 
 ![AutoscalingGraph](https://s3-eu-west-1.amazonaws.com/meyersi-ire-aws/KinesisScalingUtility/img/KinesisAutoscalingGraph.png)
 
-To get started, create a new Elastic Beanstalk application which is a Web Server with a Tomcat predefined configuration. Deploy the WAR by uploading from your local GitHub copy of [dist/KinesisAutoscaling-.9.7.0.war](dist/KinesisAutoscaling-.9.7.0.war), or using the following S3 URLs:
+To get started, create a new Elastic Beanstalk application which is a Web Server with a Tomcat predefined configuration. Deploy the WAR by uploading from your local GitHub copy of [dist/KinesisAutoscaling-.9.8.0.war](dist/KinesisAutoscaling-.9.8.0.war), or using the following S3 URLs:
 
 | region| S3 Path |
 | ----- | ------- |
-| ap-northeast-1 | https://s3.ap-northeast-1.amazonaws.com/awslabs-code-ap-northeast-1/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| ap-northeast-2 | https://s3.ap-northeast-2.amazonaws.com/awslabs-code-ap-northeast-2/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| ap-south-1 | https://s3.ap-south-1.amazonaws.com/awslabs-code-ap-south-1/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| ap-southeast-1 | https://s3.ap-southeast-1.amazonaws.com/awslabs-code-ap-southeast-1/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| ap-southeast-2 | https://s3.ap-southeast-2.amazonaws.com/awslabs-code-ap-southeast-2/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| ca-central-1 | https://s3.ca-central-1.amazonaws.com/awslabs-code-ca-central-1/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| eu-central-1 | https://s3.eu-central-1.amazonaws.com/awslabs-code-eu-central-1/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| eu-west-1 | https://s3.eu-west-1.amazonaws.com/awslabs-code-eu-west-1/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| eu-west-2 | https://s3.eu-west-2.amazonaws.com/awslabs-code-eu-west-2/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| sa-east-1 | https://s3.sa-east-1.amazonaws.com/awslabs-code-sa-east-1/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| us-east-1 | https://s3.us-east-1.amazonaws.com/awslabs-code-us-east-1/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| us-east-2 | https://s3.us-east-2.amazonaws.com/awslabs-code-us-east-2/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| us-west-1 | https://s3.us-west-1.amazonaws.com/awslabs-code-us-west-1/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
-| us-west-2 | https://s3.us-west-2.amazonaws.com/awslabs-code-us-west-2/KinesisAutoscaling/KinesisAutoscaling-.9.7.0.war | 
+| ap-northeast-1 | https://s3.ap-northeast-1.amazonaws.com/awslabs-code-ap-northeast-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| ap-northeast-2 | https://s3.ap-northeast-2.amazonaws.com/awslabs-code-ap-northeast-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| ap-south-1 | https://s3.ap-south-1.amazonaws.com/awslabs-code-ap-south-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| ap-southeast-1 | https://s3.ap-southeast-1.amazonaws.com/awslabs-code-ap-southeast-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| ap-southeast-2 | https://s3.ap-southeast-2.amazonaws.com/awslabs-code-ap-southeast-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| ca-central-1 | https://s3.ca-central-1.amazonaws.com/awslabs-code-ca-central-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| eu-central-1 | https://s3.eu-central-1.amazonaws.com/awslabs-code-eu-central-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| eu-west-1 | https://s3.eu-west-1.amazonaws.com/awslabs-code-eu-west-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| eu-west-2 | https://s3.eu-west-2.amazonaws.com/awslabs-code-eu-west-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| sa-east-1 | https://s3.sa-east-1.amazonaws.com/awslabs-code-sa-east-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| us-east-1 | https://s3.us-east-1.amazonaws.com/awslabs-code-us-east-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| us-east-2 | https://s3.us-east-2.amazonaws.com/awslabs-code-us-east-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| us-west-1 | https://s3.us-west-1.amazonaws.com/awslabs-code-us-west-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
+| us-west-2 | https://s3.us-west-2.amazonaws.com/awslabs-code-us-west-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.0.war | 
 
 Once deployed, you must configure the Autoscaling engine by providing a JSON configuration file on an HTTP or S3 URL. The structure of this configuration file is as follows:
 

--- a/bin/distribute.sh
+++ b/bin/distribute.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # set -x
 
-ver=.9.7.0
+ver=.9.8.0
 
 # publish war to regional buckets
 for r in `aws ec2 describe-regions --query Regions[*].RegionName --output text`; do aws s3 cp ../dist/KinesisAutoscaling-$ver.war s3://awslabs-code-$r/KinesisAutoscaling/ --acl public-read --region $r; done

--- a/bin/distribute.sh
+++ b/bin/distribute.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # set -x
 
-ver=.9.8.0
+ver=.9.7.0
 
 # publish war to regional buckets
 for r in `aws ec2 describe-regions --query Regions[*].RegionName --output text`; do aws s3 cp ../dist/KinesisAutoscaling-$ver.war s3://awslabs-code-$r/KinesisAutoscaling/ --acl public-read --region $r; done

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.amazonaws</groupId>
 	<artifactId>kinesis-scaling-utils</artifactId>
-	<version>.9.7.0</version>
+	<version>.9.8.0</version>
 	<properties>
 		<sdk-version>2.13.39</sdk-version>
 	</properties>

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScaler.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScaler.java
@@ -49,7 +49,7 @@ public class StreamScaler {
 
 	private final String AWSApplication = "KinesisScalingUtility";
 
-	public static final String version = ".9.6.0";
+	public static final String version = ".9.7.0";
 
 	private final NumberFormat pctFormat = NumberFormat.getPercentInstance();
 

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScaler.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScaler.java
@@ -49,7 +49,7 @@ public class StreamScaler {
 
 	private final String AWSApplication = "KinesisScalingUtility";
 
-	public static final String version = ".9.7.0";
+	public static final String version = ".9.8.0";
 
 	private final NumberFormat pctFormat = NumberFormat.getPercentInstance();
 

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/KinesisOperationType.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/KinesisOperationType.java
@@ -43,7 +43,7 @@ public enum KinesisOperationType {
 		public List<String> getMetricsToFetch() {
 			List<String> metricsToFetch = new ArrayList<>();
 			metricsToFetch.add("GetRecords.Bytes");
-			metricsToFetch.add("GetRecords.Success");
+			metricsToFetch.add("GetRecords.Records");
 			return metricsToFetch;
 		}
 	};

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetric.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetric.java
@@ -8,7 +8,7 @@
 package com.amazonaws.services.kinesis.scaling.auto;
 
 public enum StreamMetric {
-	Bytes("Bytes"), Records("Count");
+	Bytes("BYTES"), Records("COUNT");
 
 	private final String unit;
 

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetric.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMetric.java
@@ -18,7 +18,7 @@ public enum StreamMetric {
 
 	public static StreamMetric fromUnit(String unit) {
 		for (StreamMetric m : values()) {
-			if (m.unit.equals(unit)) {
+			if (m.unit.toUpperCase().equals(unit)) {
 				return m;
 			}
 		}

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
@@ -225,7 +225,7 @@ public class StreamMonitor implements Runnable {
 		// implement the decision matrix
 		if (getVote != null && putVote != null) {
 			// If either of the votes are to scale up, then do so.
-			// If any vote is DOWN, then scale down.
+			// If both votes are DOWN, then scale down.
 			// Otherwise do nothing.
 			if (getVote == ScaleDirection.UP || putVote == ScaleDirection.UP) {
 				finalScaleDirection = ScaleDirection.UP;

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
@@ -224,15 +224,15 @@ public class StreamMonitor implements Runnable {
 		// check if we have both get and put votes - if we have both then
 		// implement the decision matrix
 		if (getVote != null && putVote != null) {
-			// if either of the votes are to scale up, then do so. If both are
-			// None,
-			// then do nothing. Otherwise scale down
+			// If either of the votes are to scale up, then do so.
+			// If any vote is DOWN, then scale down.
+			// Otherwise do nothing.
 			if (getVote == ScaleDirection.UP || putVote == ScaleDirection.UP) {
 				finalScaleDirection = ScaleDirection.UP;
-			} else if (getVote == ScaleDirection.NONE && putVote == ScaleDirection.NONE) {
-				finalScaleDirection = ScaleDirection.NONE;
-			} else {
+			} else if (getVote == ScaleDirection.DOWN && putVote == ScaleDirection.DOWN) {
 				finalScaleDirection = ScaleDirection.DOWN;
+			} else {
+				finalScaleDirection = ScaleDirection.NONE;
 			}
 		} else {
 			// we only have get or put votes, so use the non-null one

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/auto/StreamMonitor.java
@@ -130,14 +130,14 @@ public class StreamMonitor implements Runnable {
 					currentMax = datapointEntry.getValue();
 					currentPct = currentMax / streamMaxCapacity.get(entry.getKey()).get(metric);
 					// keep track of the last measures
-					if (lastTime == null || new DateTime(datapointEntry.getKey().timestamp()).isAfter(lastTime)) {
+					if (lastTime == null || new DateTime(datapointEntry.getKey().timestamp().toEpochMilli()).isAfter(lastTime)) {
 						latestPct = currentPct;
 						latestMax = currentMax;
 
 						// latest average is a simple moving average
 						latestAvg = latestAvg == 0d ? currentPct : (latestAvg + currentPct) / 2;
 					}
-					lastTime = new DateTime(datapointEntry.getKey().timestamp());
+					lastTime = new DateTime(datapointEntry.getKey().timestamp().toEpochMilli());
 
 					// if the pct for the datapoint exceeds or is below the
 					// thresholds, then add low/high samples


### PR DESCRIPTION
*Description of changes:*

While testing the latest version, logs were showing all metrics as zero, like there was not traffic in the target kinesis stream. I switched to version `.9.6.0` and confirmed there is a problem with the latest version, because the `.9.6.0` works fine.

After debugging the latest version I noticed that the problem with metrics displaying zero as value is caused by `datapoint.unit().name()` returning uppercased strings.

Then I found errors in StreamMonitor related to conversions from Instant instances to Joda DateTimes.

And finally, I think we should use `GetRecords.Records` instead of `GetRecords.Success`, the former provides better information about the number of Get requests.
