### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ RUN  mvn clean package assembly:assembly
 
 FROM openjdk:8-jre-alpine
 WORKDIR /usr/local/kinesis_scaling
-COPY --from=build-env /usr/local/kinesis_scaling/target/KinesisScalingUtils-.9.8.0-complete.jar ./KinesisScalingUtils-.9.8.0-complete.jar
+COPY --from=build-env /usr/local/kinesis_scaling/target/KinesisScalingUtils-.9.8.1-complete.jar ./KinesisScalingUtils-.9.8.1-complete.jar
 COPY ./conf/configuration.json ./conf/
 ENTRYPOINT [ \
     "java", \
     "-Dconfig-file-url=/usr/local/kinesis_scaling/conf/configuration.json", \
     "-cp", \
-    "/usr/local/kinesis_scaling/KinesisScalingUtils-.9.8.0-complete.jar", \
+    "/usr/local/kinesis_scaling/KinesisScalingUtils-.9.8.1-complete.jar", \
     "com.amazonaws.services.kinesis.scaling.auto.AutoscalingController" \
 ]


### PR DESCRIPTION
Updating version in dockerfile to 9.8.1 as 9.8.0 is deprecated. Also, maven build produces new version artefact which breaks the docker build.

*Issue #, if available:*

*Description of changes:*
Bumping version in Dockerfile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
