### PR TITLE
Bumps version to 9.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ RUN  mvn clean package assembly:assembly
 
 FROM openjdk:8-jre-alpine
 WORKDIR /usr/local/kinesis_scaling
-COPY --from=build-env /usr/local/kinesis_scaling/target/KinesisScalingUtils-.9.8.2-complete.jar ./KinesisScalingUtils-.9.8.2-complete.jar
+COPY --from=build-env /usr/local/kinesis_scaling/target/KinesisScalingUtils-.9.8.3-complete.jar ./KinesisScalingUtils-.9.8.3-complete.jar
 COPY ./conf/configuration.json ./conf/
 ENTRYPOINT [ \
     "java", \
     "-Dconfig-file-url=/usr/local/kinesis_scaling/conf/configuration.json", \
     "-cp", \
-    "/usr/local/kinesis_scaling/KinesisScalingUtils-.9.8.2-complete.jar", \
+    "/usr/local/kinesis_scaling/KinesisScalingUtils-.9.8.3-complete.jar", \
     "com.amazonaws.services.kinesis.scaling.auto.AutoscalingController" \
 ]

--- a/README.md
+++ b/README.md
@@ -48,24 +48,24 @@ Below you can see a graph of how Autoscaling will keep adequate Shard capacity t
 
 ![AutoscalingGraph](https://s3-eu-west-1.amazonaws.com/meyersi-ire-aws/KinesisScalingUtility/img/KinesisAutoscalingGraph.png)
 
-To get started, create a new Elastic Beanstalk application which is a Web Server with a Tomcat predefined configuration. Deploy the WAR by uploading from your local GitHub copy of [dist/KinesisAutoscaling-.9.8.2.war](dist/KinesisAutoscaling-.9.8.2.war), or using the following S3 URLs:
+To get started, create a new Elastic Beanstalk application which is a Web Server with a Tomcat predefined configuration. Deploy the WAR by uploading from your local GitHub copy of [dist/KinesisAutoscaling-.9.8.3.war](dist/KinesisAutoscaling-.9.8.3.war), or using the following S3 URLs:
 
 | region| S3 Path |
 | ----- | ------- |
-| ap-northeast-1 | https://s3.ap-northeast-1.amazonaws.com/awslabs-code-ap-northeast-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| ap-northeast-2 | https://s3.ap-northeast-2.amazonaws.com/awslabs-code-ap-northeast-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| ap-south-1 | https://s3.ap-south-1.amazonaws.com/awslabs-code-ap-south-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| ap-southeast-1 | https://s3.ap-southeast-1.amazonaws.com/awslabs-code-ap-southeast-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| ap-southeast-2 | https://s3.ap-southeast-2.amazonaws.com/awslabs-code-ap-southeast-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| ca-central-1 | https://s3.ca-central-1.amazonaws.com/awslabs-code-ca-central-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| eu-central-1 | https://s3.eu-central-1.amazonaws.com/awslabs-code-eu-central-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| eu-west-1 | https://s3.eu-west-1.amazonaws.com/awslabs-code-eu-west-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| eu-west-2 | https://s3.eu-west-2.amazonaws.com/awslabs-code-eu-west-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| sa-east-1 | https://s3.sa-east-1.amazonaws.com/awslabs-code-sa-east-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| us-east-1 | https://s3.us-east-1.amazonaws.com/awslabs-code-us-east-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| us-east-2 | https://s3.us-east-2.amazonaws.com/awslabs-code-us-east-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| us-west-1 | https://s3.us-west-1.amazonaws.com/awslabs-code-us-west-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
-| us-west-2 | https://s3.us-west-2.amazonaws.com/awslabs-code-us-west-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.2.war | 
+| ap-northeast-1 | https://s3.ap-northeast-1.amazonaws.com/awslabs-code-ap-northeast-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| ap-northeast-2 | https://s3.ap-northeast-2.amazonaws.com/awslabs-code-ap-northeast-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| ap-south-1 | https://s3.ap-south-1.amazonaws.com/awslabs-code-ap-south-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| ap-southeast-1 | https://s3.ap-southeast-1.amazonaws.com/awslabs-code-ap-southeast-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| ap-southeast-2 | https://s3.ap-southeast-2.amazonaws.com/awslabs-code-ap-southeast-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| ca-central-1 | https://s3.ca-central-1.amazonaws.com/awslabs-code-ca-central-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| eu-central-1 | https://s3.eu-central-1.amazonaws.com/awslabs-code-eu-central-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| eu-west-1 | https://s3.eu-west-1.amazonaws.com/awslabs-code-eu-west-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| eu-west-2 | https://s3.eu-west-2.amazonaws.com/awslabs-code-eu-west-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| sa-east-1 | https://s3.sa-east-1.amazonaws.com/awslabs-code-sa-east-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| us-east-1 | https://s3.us-east-1.amazonaws.com/awslabs-code-us-east-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| us-east-2 | https://s3.us-east-2.amazonaws.com/awslabs-code-us-east-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| us-west-1 | https://s3.us-west-1.amazonaws.com/awslabs-code-us-west-1/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
+| us-west-2 | https://s3.us-west-2.amazonaws.com/awslabs-code-us-west-2/KinesisAutoscaling/KinesisAutoscaling-.9.8.3.war | 
 
 Once deployed, you must configure the Autoscaling engine by providing a JSON configuration file on an HTTP or S3 URL. The structure of this configuration file is as follows:
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #set -x
 
-ver=.9.8.2
+ver=.9.8.3
 
 for r in `aws ec2 describe-regions --query Regions[*].RegionName --output text`; do 
 	aws s3 cp dist/KinesisAutoscaling-$ver.war s3://awslabs-code-$r/KinesisAutoscaling/KinesisAutoscaling-$ver.war --acl public-read --region $r

--- a/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScaler.java
+++ b/src/main/java/com/amazonaws/services/kinesis/scaling/StreamScaler.java
@@ -49,7 +49,7 @@ public class StreamScaler {
 
 	private final String AWSApplication = "KinesisScalingUtility";
 
-	public static final String version = ".9.8.2";
+	public static final String version = ".9.8.3";
 
 	private final NumberFormat pctFormat = NumberFormat.getPercentInstance();
 


### PR DESCRIPTION
*Issue #, if available:*

The Docker build is currently failing because it expects a jar file with version 9.8.2 but the application has been updated to version 9.8.3 with this commit - https://github.com/awslabs/amazon-kinesis-scaling-utils/commit/81b6fb848523fa730f6e79f32d40cfdef81d91a0

*Description of changes:*

Changes version throughout application to 9.8.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
