### PR TITLE
Upgrading AWS SDK to 2.15.77 and including AWS STS SDK for EKS IRSA S…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>kinesis-scaling-utils</artifactId>
 	<version>.9.8.3</version>
 	<properties>
-		<sdk-version>2.15.60</sdk-version>
+		<sdk-version>2.15.77</sdk-version>
 	</properties>
 	<licenses>
 		<license>
@@ -111,6 +111,11 @@
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sts</artifactId>
+			<version>${sdk-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.amazonaws</groupId>
 	<artifactId>kinesis-scaling-utils</artifactId>
-	<version>.9.8.3</version>
+	<version>.9.8.4</version>
 	<properties>
 		<sdk-version>2.15.77</sdk-version>
 	</properties>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To support EKS IAM Roles for Service Account, AWS SDK's are bumped up to 2.15.77 and AWS STS SDK is included as dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
